### PR TITLE
Fix "go vet" errors for incorrect printf verb

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -286,7 +286,7 @@ func (m *Mock) AssertNumberOfCalls(t TestingT, methodName string, expectedCalls 
 // AssertCalled asserts that the method was called.
 func (m *Mock) AssertCalled(t TestingT, methodName string, arguments ...interface{}) bool {
 	if !assert.True(t, m.methodWasCalled(methodName, arguments), fmt.Sprintf("The \"%s\" method should have been called with %d argument(s), but was not.", methodName, len(arguments))) {
-		t.Logf("%s", m.ExpectedCalls)
+		t.Logf("%v", m.ExpectedCalls)
 		return false
 	}
 	return true
@@ -295,7 +295,7 @@ func (m *Mock) AssertCalled(t TestingT, methodName string, arguments ...interfac
 // AssertNotCalled asserts that the method was not called.
 func (m *Mock) AssertNotCalled(t TestingT, methodName string, arguments ...interface{}) bool {
 	if !assert.False(t, m.methodWasCalled(methodName, arguments), fmt.Sprintf("The \"%s\" method was called with %d argument(s), but should NOT have been.", methodName, len(arguments))) {
-		t.Logf("%s", m.ExpectedCalls)
+		t.Logf("%v", m.ExpectedCalls)
 		return false
 	}
 	return true


### PR DESCRIPTION
github.com/stretchr/testify/mock/mock.go:289: arg m.ExpectedCalls for printf verb %s of wrong type: []mock.Call  
github.com/stretchr/testify/mock/mock.go:298: arg m.ExpectedCalls for printf verb %s of wrong type: []mock.Call
